### PR TITLE
Extract shared numeric parsing helpers

### DIFF
--- a/src/Diamond.Procurement.App/Processing/CnsInventoryProcessor.cs
+++ b/src/Diamond.Procurement.App/Processing/CnsInventoryProcessor.cs
@@ -98,13 +98,13 @@ public sealed class CnsInventoryProcessor : BaseExcelProcessor, IFileProcessor, 
             var pack = 1;
             if (map.Pack > 0)
             {
-                pack = SafeToInt(row.Cell(map.Pack));
+                pack = row.Cell(map.Pack).GetIntOrDefault();
                 if (pack <= 0) pack = 1;
             }
 
             // Raw values
-            var onHand = SafeToInt(row.Cell(map.Boh));
-            var onPo = SafeToInt(row.Cell(map.OnOrder));
+            var onHand = row.Cell(map.Boh).GetIntOrDefault();
+            var onPo = row.Cell(map.OnOrder).GetIntOrDefault();
             var avg13 = row.Cell(map.Avg13).GetDouble();
             if (avg13 < 0) avg13 = 0;
 
@@ -151,20 +151,5 @@ public sealed class CnsInventoryProcessor : BaseExcelProcessor, IFileProcessor, 
         }
 
         await _repo.LoadAsync(rows, ct);
-    }
-
-    private static int SafeToInt(IXLCell cell)
-    {
-        if (cell.DataType == XLDataType.Number)
-            return (int)Math.Round(cell.GetDouble());
-
-        var s = (cell.GetString() ?? string.Empty).Trim();
-        if (int.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var n))
-            return n;
-
-        if (double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var d))
-            return (int)Math.Round(d);
-
-        return 0;
     }
 }

--- a/src/Diamond.Procurement.App/Processing/DgInventoryProcessor.cs
+++ b/src/Diamond.Procurement.App/Processing/DgInventoryProcessor.cs
@@ -59,7 +59,7 @@ public sealed class DgInventoryProcessor
             var desc = (row.Cell(map.Description).GetString() ?? string.Empty).Trim();
 
             // CasePack still mapped, but not used for weekly eaches calc.
-            var casePack = SafeToInt(row.Cell(map.CasePack));
+            var casePack = row.Cell(map.CasePack).GetIntOrDefault();
             if (casePack <= 0) casePack = 1;
 
             // Avg Wkly Mvmnt is already IN EACHES
@@ -97,11 +97,6 @@ public sealed class DgInventoryProcessor
 
         await _repo.LoadAsync(outRows, ct);
     }
-
-    private static int SafeToInt(IXLCell cell)
-        => cell.DataType == XLDataType.Number ? (int)Math.Round(cell.GetDouble())
-           : int.TryParse((cell.GetString() ?? "").Trim(), NumberStyles.Any, CultureInfo.InvariantCulture, out var n) ? n
-           : (double.TryParse((cell.GetString() ?? "").Trim(), NumberStyles.Any, CultureInfo.InvariantCulture, out var d) ? (int)Math.Round(d) : 0);
 
     private static decimal SafeToDecimal(IXLCell cell)
         => cell.DataType == XLDataType.Number ? (decimal)cell.GetDouble()

--- a/src/Diamond.Procurement.App/Processing/MainframeInventoryProcessor.cs
+++ b/src/Diamond.Procurement.App/Processing/MainframeInventoryProcessor.cs
@@ -54,45 +54,6 @@ public sealed class MainframeInventoryProcessor : IFileProcessor
             throw new InvalidOperationException($"Could not find header: {string.Join(", ", candidates)}");
         }
 
-        static int ParseMainframeInt(string? raw)
-        {
-            // Handles: "123", "-123", "123-", "1,234", "1,234-"
-            var s = (raw ?? string.Empty).Trim();
-            if (string.IsNullOrEmpty(s)) return 0;
-
-            s = s.Replace(",", "");
-            bool trailingMinus = s.EndsWith('-');
-            if (trailingMinus) s = s[..^1];
-
-            if (int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val))
-                return trailingMinus ? -val : val;
-
-            return int.TryParse((raw ?? "").Trim(), out var v) ? v : 0;
-        }
-
-        static decimal? ParseMoney(string? raw)
-        {
-            // Accept: "$1,234.56", "1,234.56", "(1,234.56)", "1234", "1234-"
-            var s = (raw ?? string.Empty).Trim();
-            if (string.IsNullOrEmpty(s)) return null;
-
-            var neg = false;
-            if (s.EndsWith("-", StringComparison.Ordinal))
-            {
-                neg = true; s = s[..^1];
-            }
-            if (s.StartsWith("(") && s.EndsWith(")"))
-            {
-                neg = true; s = s.Trim('(', ')');
-            }
-
-            s = s.Replace("$", "").Replace(",", "");
-            if (decimal.TryParse(s, NumberStyles.Number | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var val))
-                return neg ? -val : val;
-
-            return null;
-        }
-
         var hUpc = FindHeader("UPC");
         var hCspk = FindHeader("CSPK");
         var hQty = FindHeader("QTY~AVL");
@@ -115,12 +76,12 @@ public sealed class MainframeInventoryProcessor : IFileProcessor
             if (int.TryParse((cspkStr ?? string.Empty).Trim(), out var cp) && cp > 0)
                 casePack = cp;
 
-            var qty = ParseMainframeInt(csv.GetField(hQty));
-            var onpo = ParseMainframeInt(csv.GetField(hOnPo));
-            var ovstk = ParseMainframeInt(csv.GetField(hOvstk));
-            var list = ParseMoney(csv.GetField(hList)); // NEW
-            var hi = ParseMainframeInt(csv.GetField(hHi));
-            var ti = ParseMainframeInt(csv.GetField(hTi));
+            var qty = NumericParsers.ParseSignedIntOrDefault(csv.GetField(hQty));
+            var onpo = NumericParsers.ParseSignedIntOrDefault(csv.GetField(hOnPo));
+            var ovstk = NumericParsers.ParseSignedIntOrDefault(csv.GetField(hOvstk));
+            var list = NumericParsers.ParseMoney(csv.GetField(hList));
+            var hi = NumericParsers.ParseSignedIntOrDefault(csv.GetField(hHi));
+            var ti = NumericParsers.ParseSignedIntOrDefault(csv.GetField(hTi));
 
             rows.Add(new MainframeInventoryRow
             {

--- a/src/Diamond.Procurement.App/Processing/MeijerInventoryProcessor.cs
+++ b/src/Diamond.Procurement.App/Processing/MeijerInventoryProcessor.cs
@@ -65,12 +65,12 @@ public sealed class MeijerInventoryProcessor : BaseExcelProcessor, IFileProcesso
             var desc = map.Description > 0 ? (row.Cell(map.Description).GetString() ?? "").Trim() : "";
 
             // CasePack
-            var casePack = SafeToInt(row.Cell(map.CasePackQty));
+            var casePack = row.Cell(map.CasePackQty).GetIntOrDefault();
             if (casePack <= 0) casePack = 1;
 
             // Movement mapping:
             // Original 52-week annualized value → UnitsSoldLastYear; compute SalesYTD from it.
-            var annual = SafeToInt(row.Cell(map.Sales52Week)); // integer “annualized” count
+            var annual = row.Cell(map.Sales52Week).GetIntOrDefault(); // integer “annualized” count
             var weekly = annual / 52.0;
             var ytd = (int)Math.Round(weekly * weeksElapsed, MidpointRounding.AwayFromZero);
 
@@ -106,13 +106,4 @@ public sealed class MeijerInventoryProcessor : BaseExcelProcessor, IFileProcesso
         await _repo.LoadAsync(rows, ct);
     }
 
-    private static int SafeToInt(IXLCell cell)
-    {
-        if (cell.DataType == XLDataType.Number) return (int)Math.Round(cell.GetDouble());
-
-        var s = (cell.GetString() ?? string.Empty).Trim();
-        if (int.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var n)) return n;
-        if (double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var d)) return (int)Math.Round(d);
-        return 0;
-    }
 }

--- a/src/Diamond.Procurement.App/Processing/UpcCompProcessor.cs
+++ b/src/Diamond.Procurement.App/Processing/UpcCompProcessor.cs
@@ -53,10 +53,10 @@ namespace Diamond.Procurement.App.Processing
                 if (!UpcNormalizer.TryNormalizeTo10(rawUpc, out var upc, out _))
                     continue;
 
-                decimal? priceVI = ParseMoney(csv.GetField(idxVical));
-                int? qtyVI = ParseInt(csv.GetField(idxVicalQty));
-                decimal? priceQK = ParseMoney(csv.GetField(idxQkall));
-                int? qtyQK = ParseInt(csv.GetField(idxQkallQty));
+                decimal? priceVI = NumericParsers.ParseMoney(csv.GetField(idxVical));
+                int? qtyVI = NumericParsers.ParseOptionalSignedInt(csv.GetField(idxVicalQty));
+                decimal? priceQK = NumericParsers.ParseMoney(csv.GetField(idxQkall));
+                int? qtyQK = NumericParsers.ParseOptionalSignedInt(csv.GetField(idxQkallQty));
 
                 // Skip rows that carry no useful signal
                 if (priceVI is null && qtyVI is null && priceQK is null && qtyQK is null)
@@ -87,35 +87,5 @@ namespace Diamond.Procurement.App.Processing
             throw new InvalidOperationException($"Could not find column header '{target}'.");
         }
 
-        private static int? ParseInt(string? raw)
-        {
-            if (string.IsNullOrWhiteSpace(raw)) return null;
-            var s = raw.Trim().Replace(",", "");
-            bool trailingMinus = s.EndsWith("-");
-            if (trailingMinus) s = s[..^1];
-            if (int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val))
-                return trailingMinus ? -val : val;
-            return null;
-        }
-
-        private static decimal? ParseMoney(string? raw)
-        {
-            if (string.IsNullOrWhiteSpace(raw)) return null;
-            var s = raw.Trim();
-            bool trailingMinus = s.EndsWith("-");
-            if (trailingMinus) s = s[..^1];
-
-            if (s.StartsWith("(") && s.EndsWith(")"))
-            {
-                s = s[1..^1];
-                trailingMinus = true;
-            }
-            s = s.Replace("$", "").Replace(",", "");
-
-            if (decimal.TryParse(s, NumberStyles.Number | NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var d))
-                return trailingMinus ? -d : d;
-
-            return null;
-        }
     }
 }

--- a/src/Diamond.Procurement.Domain/Util/NumericParsers.cs
+++ b/src/Diamond.Procurement.Domain/Util/NumericParsers.cs
@@ -1,0 +1,82 @@
+using System.Globalization;
+
+namespace Diamond.Procurement.Domain.Util;
+
+public static class NumericParsers
+{
+    public static bool TryParseSignedInt(string? raw, out int value)
+    {
+        value = 0;
+        if (string.IsNullOrWhiteSpace(raw))
+            return false;
+
+        var trimmed = raw.Trim();
+
+        if (TryParseCore(trimmed.Replace(",", string.Empty), out value))
+            return true;
+
+        if (TryParseCore(trimmed, out value))
+            return true;
+
+        if (int.TryParse(trimmed, out value))
+            return true;
+
+        return false;
+    }
+
+    public static int ParseSignedIntOrDefault(string? raw, int defaultValue = 0)
+        => TryParseSignedInt(raw, out var value) ? value : defaultValue;
+
+    public static int? ParseOptionalSignedInt(string? raw)
+        => TryParseSignedInt(raw, out var value) ? value : null;
+
+    public static decimal? ParseMoney(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+
+        var s = raw.Trim();
+        var negative = false;
+
+        if (s.EndsWith("-", StringComparison.Ordinal))
+        {
+            negative = true;
+            s = s[..^1];
+        }
+
+        if (s.StartsWith("(", StringComparison.Ordinal) && s.EndsWith(")", StringComparison.Ordinal))
+        {
+            negative = true;
+            s = s[1..^1];
+        }
+
+        s = s.Replace("$", string.Empty).Replace(",", string.Empty);
+
+        if (decimal.TryParse(s, NumberStyles.Number | NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var value))
+            return negative ? -value : value;
+
+        return null;
+    }
+
+    private static bool TryParseCore(string input, out int value)
+    {
+        value = 0;
+        if (string.IsNullOrEmpty(input))
+            return false;
+
+        var s = input;
+        var negative = false;
+
+        if (s.EndsWith("-", StringComparison.Ordinal))
+        {
+            negative = true;
+            s = s[..^1];
+        }
+
+        if (!int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            return false;
+
+        value = negative ? -parsed : parsed;
+        return true;
+    }
+}

--- a/src/Diamond.Procurement.Domain/Util/XlExtensions.cs
+++ b/src/Diamond.Procurement.Domain/Util/XlExtensions.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using ClosedXML.Excel;
 
 namespace Diamond.Procurement.Domain.Util;
@@ -10,12 +11,27 @@ public static class XlExtensions
             return c.GetDouble();
 
         var s = c.GetString();
-        if (double.TryParse(s, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var d))
+        if (double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var d))
             return d;
 
         if (double.TryParse(s, out d))
             return d;
 
         return 0d;
+    }
+
+    public static int GetIntOrDefault(this IXLCell cell)
+    {
+        if (cell.DataType == XLDataType.Number)
+            return (int)Math.Round(cell.GetDouble());
+
+        var text = cell.GetString();
+        if (NumericParsers.TryParseSignedInt(text, out var value))
+            return value;
+
+        if (double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out var d))
+            return (int)Math.Round(d);
+
+        return 0;
     }
 }


### PR DESCRIPTION
## Summary
- add shared `NumericParsers` helpers for trailing-minus integers and flexible currency parsing
- extend `XlExtensions` with `GetIntOrDefault` and update Excel processors to reuse it
- update CSV processors to consume the shared helpers and drop duplicate parsing code

## Testing
- `dotnet build Diamond.Procurement.sln` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a9d48794832facb2113a356181cd