### PR TITLE
Add ClickOnce update availability indicator

### DIFF
--- a/Diamond.Procurement.Win/Forms/frmLandingPage.Designer.cs
+++ b/Diamond.Procurement.Win/Forms/frmLandingPage.Designer.cs
@@ -17,6 +17,10 @@
             {
                 components.Dispose();
             }
+            if (disposing)
+            {
+                _updateCheckTimer?.Dispose();
+            }
             base.Dispose(disposing);
         }
 
@@ -34,6 +38,7 @@
             navigationFrame1 = new DevExpress.XtraBars.Navigation.NavigationFrame();
             navigationPage1 = new DevExpress.XtraBars.Navigation.NavigationPage();
             accordionControl1 = new DevExpress.XtraBars.Navigation.AccordionControl();
+            accordionControlElementUpdateAvailable = new DevExpress.XtraBars.Navigation.AccordionControlElement();
             accordionControlElement1 = new DevExpress.XtraBars.Navigation.AccordionControlElement();
             accordionControlElement2 = new DevExpress.XtraBars.Navigation.AccordionControlElement();
             accordionControlElement3 = new DevExpress.XtraBars.Navigation.AccordionControlElement();
@@ -87,7 +92,7 @@
             accordionControl1.Appearance.Item.Default.Font = new Font("Tahoma", 8.25F, FontStyle.Regular, GraphicsUnit.Point, 0);
             accordionControl1.Appearance.Item.Default.Options.UseFont = true;
             accordionControl1.Dock = DockStyle.Left;
-            accordionControl1.Elements.AddRange(new DevExpress.XtraBars.Navigation.AccordionControlElement[] { accordionControlElement1, accordionControlElement4, accordionControlElement8 });
+            accordionControl1.Elements.AddRange(new DevExpress.XtraBars.Navigation.AccordionControlElement[] { accordionControlElementUpdateAvailable, accordionControlElement1, accordionControlElement4, accordionControlElement8 });
             accordionControl1.Location = new Point(0, 31);
             accordionControl1.Name = "accordionControl1";
             accordionControl1.OptionsMinimizing.AllowMinimizeMode = DevExpress.Utils.DefaultBoolean.True;
@@ -95,9 +100,19 @@
             accordionControl1.Size = new Size(208, 728);
             accordionControl1.TabIndex = 1;
             accordionControl1.ViewType = DevExpress.XtraBars.Navigation.AccordionControlViewType.HamburgerMenu;
-            // 
+            // accordionControlElementUpdateAvailable
+            //
+            accordionControlElementUpdateAvailable.Appearance.Normal.ForeColor = Color.FromArgb(230, 126, 34);
+            accordionControlElementUpdateAvailable.Appearance.Normal.Options.UseForeColor = true;
+            accordionControlElementUpdateAvailable.ImageOptions.SvgImageSize = new Size(16, 16);
+            accordionControlElementUpdateAvailable.Name = "accordionControlElementUpdateAvailable";
+            accordionControlElementUpdateAvailable.Style = DevExpress.XtraBars.Navigation.ElementStyle.Item;
+            accordionControlElementUpdateAvailable.Tag = "update";
+            accordionControlElementUpdateAvailable.Text = "Update available - click to restart";
+            accordionControlElementUpdateAvailable.Visible = false;
+            //
             // accordionControlElement1
-            // 
+            //
             accordionControlElement1.Elements.AddRange(new DevExpress.XtraBars.Navigation.AccordionControlElement[] { accordionControlElement2, accordionControlElement3, accordionControlElement9 });
             accordionControlElement1.Expanded = true;
             accordionControlElement1.Name = "accordionControlElement1";
@@ -220,6 +235,7 @@
         private DevExpress.XtraBars.Navigation.AccordionControlElement accordionControlElement5;
         private DevExpress.XtraBars.Navigation.AccordionControlElement accordionControlElement6;
         private DevExpress.XtraBars.Navigation.AccordionControlElement accordionControlElement7;
+        private DevExpress.XtraBars.Navigation.AccordionControlElement accordionControlElementUpdateAvailable;
         private DevExpress.XtraBars.Navigation.AccordionControlElement accordionControlElement8;
         private DevExpress.XtraBars.Navigation.AccordionControlElement accordionControlElement9;
     }

--- a/Diamond.Procurement.Win/Helpers/ClickOnceUpdateChecker.cs
+++ b/Diamond.Procurement.Win/Helpers/ClickOnceUpdateChecker.cs
@@ -1,0 +1,44 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using System.Windows.Forms;
+
+namespace Diamond.Procurement.Win.Helpers;
+
+public static class ClickOnceUpdateChecker
+{
+    private static readonly HttpClient HttpClient = new();
+
+    public static async Task<Version?> GetDeploymentVersionAsync(string manifestUrl, CancellationToken cancellationToken = default)
+    {
+        using var response = await HttpClient.GetAsync(manifestUrl, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var document = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
+
+        var assemblyIdentity = document
+            .Descendants()
+            .FirstOrDefault(e => string.Equals(e.Name.LocalName, "assemblyIdentity", StringComparison.OrdinalIgnoreCase));
+
+        var versionValue = assemblyIdentity?.Attribute("version")?.Value;
+        if (Version.TryParse(versionValue, out var version))
+        {
+            return version;
+        }
+
+        return null;
+    }
+
+    public static Version GetCurrentVersion()
+    {
+        var versionString = Application.ProductVersion;
+        if (Version.TryParse(versionString, out var version))
+        {
+            return version;
+        }
+
+        return new Version(0, 0, 0, 0);
+    }
+}

--- a/Diamond.Procurement.Win/appsettings.Development.json
+++ b/Diamond.Procurement.Win/appsettings.Development.json
@@ -4,5 +4,9 @@
   },
   "Serilog": {
     "MinimumLevel": "Debug"
+  },
+  "Deployment": {
+    "ManifestUrl": "https://diamondorders.blob.core.windows.net/$web/Diamond.Procurement.Win.application",
+    "UpdateCheckMinutes": 60
   }
 }

--- a/Diamond.Procurement.Win/appsettings.json
+++ b/Diamond.Procurement.Win/appsettings.json
@@ -4,5 +4,9 @@
   },
   "Serilog": {
     "MinimumLevel": "Information"
+  },
+  "Deployment": {
+    "ManifestUrl": "https://diamondorders.blob.core.windows.net/$web/Diamond.Procurement.Win.application",
+    "UpdateCheckMinutes": 60
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable ClickOnce update checker that reads the deployment manifest version
- integrate a timer-driven update check on the landing page and surface an update banner in the navigation accordion
- store the deployment manifest URL and polling interval in configuration for easy changes

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d69030a1f4832f86d9a74f5a4eff45